### PR TITLE
See different versions of tagging for the prototype

### DIFF
--- a/app/controllers/whitehall_controller.rb
+++ b/app/controllers/whitehall_controller.rb
@@ -1,10 +1,11 @@
 class WhitehallController < ApplicationController
+  before_action :process_parameters, except: [:tagging]
+
   def detailed_guide
   end
 
   def tagging
   end
-
 
   def organisations
     @organisations = JSON.parse(File.open('app/data/organisations.json').read)['results'].sort_by { |r| r['title'] }
@@ -25,4 +26,26 @@ class WhitehallController < ApplicationController
     @policy_areas = JSON.parse(File.open('app/data/policy_areas.json').read)['results'].sort_by! { |r| r['title'] }
   end
   helper_method :policy_areas
+
+  def ministers
+    @ministers = JSON.parse(File.open('app/data/ministers.json').read)['results'].sort_by! { |r| r['title'] }
+  end
+  helper_method :ministers
+
+  def locations
+    @ministers = JSON.parse(File.open('app/data/world_locations.json').read)['results'].sort_by! { |r| r['title'] }
+  end
+  helper_method :locations
+
+  private
+
+  def process_parameters
+    # playing with seeing different forms of tagging page
+    @version = params['v']
+    if @version
+      session[:version] = @version
+    else
+      session[:version] = 'b'
+    end
+  end
 end

--- a/app/data/ministers.json
+++ b/app/data/ministers.json
@@ -1,0 +1,7 @@
+{
+    "results" : [
+        { "title" : "Pitt Elder", "slug" : "/pitt-elder" },
+        { "title" : "Pitt Younger", "slug" : "/pitt-younger" },
+        { "title" : "Oliver Cromwell", "slug" : "/oliver-cromwell" }
+    ]
+}

--- a/app/data/world_locations.json
+++ b/app/data/world_locations.json
@@ -1,0 +1,7 @@
+{
+    "results" : [
+        { "title" : "Antarctica", "slug" : "/antarctica" },
+        { "title" : "Syria", "slug" : "/syria" },
+        { "title" : "Nepal", "slug" : "/nepal" }
+    ]
+}

--- a/app/views/partials/_a.html.erb
+++ b/app/views/partials/_a.html.erb
@@ -1,0 +1,8 @@
+<label for="edition_edition[lead_organisation_ids][]">Organisations</label>
+
+<select multiple="multiple" name="edition[lead_organisation_ids][]" id="edition_lead_organisation_ids_1" class="chzn-select form-control" data-placeholder="Choose organisations…">
+  <option value=""></option>
+  <% organisations.each do |org| %>
+  <option value="<%= org['slug'] %>"><%= org['title'] %></option>
+  <% end %>
+</select>

--- a/app/views/partials/_b.html.erb
+++ b/app/views/partials/_b.html.erb
@@ -1,0 +1,22 @@
+<fieldset>
+  <legend class="visuallyhidden">Polices and policy areas</legend>
+  <label for="edition_policy_content_ids">Policies</label>
+  <input name="edition[policy_content_ids][]" type="hidden" value="" />
+  <select multiple="multiple" class="chzn-select form-control" data-placeholder="Choose policies…" name="edition[policy_content_ids][]" id="edition_policy_content_ids">
+    <option value=""></option>
+
+    <% policies.each do |pol| %>
+    <option value="<%= pol['slug'] %>"><%= pol['title'] %></option>
+    <% end %>
+  </select>
+
+  <label class="required" for="edition_topic_ids">Policy Areas (this is the new name for Topics)<span>*</span></label>
+  <input name="edition[topic_ids][]" type="hidden" value="" />
+  <select multiple="multiple" class="chzn-select form-control" data-placeholder="Choose topics…" name="edition[topic_ids][]" id="edition_topic_ids">
+    <option value=""></option>
+
+    <% policy_areas.each do |pol| %>
+    <option value="<%= pol['slug'] %>"><%= pol['title'] %></option>
+    <% end %>
+  </select>
+</fieldset>

--- a/app/views/partials/_c.html.erb
+++ b/app/views/partials/_c.html.erb
@@ -1,0 +1,8 @@
+<label for="edition_edition[lead_organisation_ids][]">Ministers</label>
+
+<select multiple="multiple" name="edition[lead_organisation_ids][]" id="edition_lead_organisation_ids_1" class="chzn-select form-control" data-placeholder="Choose ministers…">
+  <option value=""></option>
+  <% ministers.each do |minister| %>
+  <option value="<%= minister['slug'] %>"><%= minister['title'] %></option>
+  <% end %>
+</select>

--- a/app/views/partials/_d.html.erb
+++ b/app/views/partials/_d.html.erb
@@ -1,0 +1,8 @@
+<label for="edition_edition[world_locations][]">World locations</label>
+
+<select multiple="multiple" name="edition[world_locations][]" id="edition_world_locations_1" class="chzn-select form-control" data-placeholder="Choose locations…">
+  <option value=""></option>
+  <% locations.each do |location| %>
+  <option value="<%= location['slug'] %>"><%= location['title'] %></option>
+  <% end %>
+</select>

--- a/app/views/partials/_e.html.erb
+++ b/app/views/partials/_e.html.erb
@@ -1,0 +1,3 @@
+<% ['a','b','c','d'].each do |version| %>
+  <%= render "partials/#{version}" %>
+<% end %>

--- a/app/views/whitehall/index.html.erb
+++ b/app/views/whitehall/index.html.erb
@@ -1,5 +1,9 @@
 <ul>
-  <li><a href="/detailed_guide">Detailed guide</a></li>
-  <li><a href="/news_article">News article</a></li>
-  <li><a href="/publication">Publication</a></li>
+  <li><a href="/detailed_guide?v=a">Detailed guide: Organisation tagging</a></li>
+  <li><a href="/detailed_guide?v=b">Detailed guide: Policy tagging</a></li>
+  <li><a href="/detailed_guide?v=e">Detailed guide: Minister/Organisation/Policy/Location tagging</a></li>
+
+  <li><a href="/news_article?v=c">News article: Minister tagging</a></li>
+
+  <li><a href="/publication?v=d">Publication: World locations tagging</a></li>
 </ul>

--- a/app/views/whitehall/tagging.html.erb
+++ b/app/views/whitehall/tagging.html.erb
@@ -20,7 +20,8 @@
       <div class="tab-content">
         <form class="edition-form js-edition-form" id="new_edition" enctype="multipart/form-data" action="/government/admin/detailed-guides" accept-charset="UTF-8" method="post">
 
-          <%= render 'partials/policies', locals: { policy_areas: policy_areas, policies: policies } %>
+          <% tagging_page = "partials/#{session[:version]}" %>
+          <%= render tagging_page %>
 
           <%= render 'partials/topic_subtopic', locals: { topics: topics } %>
 


### PR DESCRIPTION
Show different versions of the tagging page for Detailed Guides, Publications, and News stories.

This code stores which version of tagging to see in the session hash.

Quick and dirty!
